### PR TITLE
feat: add CLI command to command-line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ packages = [
   { include = "sidechain_cli" },
 ]
 
+[tool.poetry.scripts]
+sidechain-cli = 'sidechain_cli.main:main'
+
 [tool.poetry.dependencies]
 python = "^3.7.1"
 click = "^8.1.3"


### PR DESCRIPTION
## High Level Overview of Change

This PR actually adds the CLI command to the install process. Now, after installing the package, users will have a CLI command, `sidechain-cli`, with which to interact with the CLI.

### Context of Change

needed for release and usage

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works when tested locally.
