### PR TITLE
feat: store data in CLI config file

### DIFF
--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -44,8 +44,10 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         config: The filepath to the rippled config file.
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
-    if check_chain_exists(name):
-        print("Error: Chain already running with that name.")
+    rippled = os.path.abspath(rippled)
+    config = os.path.abspath(config)
+    if check_chain_exists(name, config):
+        print("Error: Chain already running with that name or config.")
         return
     to_run = [rippled, "--conf", config, "-a"]
     if verbose:
@@ -55,8 +57,8 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
     pid = process.pid
     chain_data: ChainData = {
         "name": name,
-        "rippled": os.path.abspath(rippled),
-        "config": os.path.abspath(config),
+        "rippled": rippled,
+        "config": config,
         "pid": pid,
     }
     add_chain(chain_data)

--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -63,6 +63,7 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         "config": config,
         "pid": pid,
     }
+    # TODO: add some sort of check that rippled actually started
     add_chain(chain_data)
     if verbose:
         print(f"started rippled: {rippled} PID: {pid}", flush=True)

--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import click
 
+from sidechain_cli.utils.config_file import add_chain
+
 
 @click.command(name="start")
 @click.option(
@@ -47,6 +49,13 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         to_run, stdout=fout, stderr=subprocess.STDOUT, close_fds=True
     )
     pid = process.pid
+    chain_data = {
+        "name": name,
+        "rippled": rippled,
+        "config": config,
+        "pid": pid,
+    }
+    add_chain(chain_data)
     if verbose:
         print(f"started rippled: {rippled} PID: {pid}", flush=True)
 

--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import click
 
-from sidechain_cli.utils.config_file import add_chain
+from sidechain_cli.utils import ChainData, add_chain
 
 
 @click.command(name="start")
@@ -49,7 +49,7 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         to_run, stdout=fout, stderr=subprocess.STDOUT, close_fds=True
     )
     pid = process.pid
-    chain_data = {
+    chain_data: ChainData = {
         "name": name,
         "rippled": rippled,
         "config": config,
@@ -62,7 +62,9 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
 
 @click.command(name="stop")
 @click.option("--name", help="The name of the chain to stop.")
-@click.option("--all", is_flag=True, help="Whether to stop all of the chains.")
+@click.option(
+    "--all", "stop_all", is_flag=True, help="Whether to stop all of the chains."
+)
 def stop_chain(name: Optional[str] = None, stop_all: bool = False) -> None:
     """
     Stop a rippled node(s).

--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -53,7 +53,9 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
     if verbose:
         print("Starting server...")
     fout = open(os.devnull, "w")
-    process = subprocess.Popen(to_run, stdout=fout, close_fds=True)
+    process = subprocess.Popen(
+        to_run, stdout=fout, stderr=subprocess.STDOUT, close_fds=True
+    )
     pid = process.pid
     chain_data: ChainData = {
         "name": name,
@@ -88,7 +90,9 @@ def stop_chain(name: Optional[str] = None, stop_all: bool = False) -> None:
 
 @click.command(name="restart")
 @click.option("--name", help="The name of the chain to restart.")
-@click.option("--all", is_flag=True, help="Whether to restart all of the chains.")
+@click.option(
+    "--all", "restart_all", is_flag=True, help="Whether to stop all of the chains."
+)
 def restart_chain(name: Optional[str] = None, restart_all: bool = False) -> None:
     """
     Restart a rippled node(s).

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Util methods for the sidechain CLI."""

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -1,1 +1,6 @@
 """Util methods for the sidechain CLI."""
+
+from sidechain_cli.utils.config_utils import add_chain
+from sidechain_cli.utils.types import ChainData
+
+__all__ = ["add_chain", "ChainData"]

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -1,6 +1,6 @@
 """Util methods for the sidechain CLI."""
 
-from sidechain_cli.utils.config_utils import add_chain
+from sidechain_cli.utils.config_utils import add_chain, check_chain_exists
 from sidechain_cli.utils.types import ChainData
 
-__all__ = ["add_chain", "ChainData"]
+__all__ = ["add_chain", "check_chain_exists", "ChainData"]

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -1,4 +1,4 @@
-"""Methods to do with the config file."""
+"""ConfigFile helper class."""
 
 from __future__ import annotations
 
@@ -61,19 +61,3 @@ class ConfigFile:
         """Write the ConfigFile data to file."""
         with open(_CONFIG_FILE, "w") as f:
             json.dump(self.to_dict(), f, indent=4)
-
-
-def _get_config() -> ConfigFile:
-    return ConfigFile.from_file()
-
-
-def add_chain(chain_data: Dict[str, Any]) -> None:
-    """
-    Add a chain's data to the config file.
-
-    Args:
-        chain_data: The data of the chain to add.
-    """
-    conf = _get_config()
-    conf.chains.append(chain_data)
-    conf.write_to_file()

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -11,6 +11,7 @@ _HOME = str(Path.home())
 
 _CONFIG_FOLDER = os.path.join(_HOME, ".config", "sidechain-cli")
 
+# ~/.config/sidechain-cli/config.json
 _CONFIG_FILE = os.path.join(_CONFIG_FOLDER, "config.json")
 
 # Initialize config file

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -20,6 +20,9 @@ if not os.path.exists(_CONFIG_FILE):
         data: Dict[str, Any] = {"chains": []}
         json.dump(data, f, indent=4)
 
+# TODO: consider having separate JSONs for each node type
+# (e.g. chains.json, witnesses.json)
+
 
 class ConfigFile:
     """Helper class for working with the config file."""

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -1,0 +1,76 @@
+"""Methods to do with the config file."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Type
+
+_HOME = str(Path.home())
+
+_CONFIG_FOLDER = os.path.join(_HOME, ".config", "sidechain-cli")
+
+_CONFIG_FILE = os.path.join(_CONFIG_FOLDER, "config.json")
+
+# Initialize config file
+Path(_CONFIG_FOLDER).mkdir(parents=True, exist_ok=True)
+if not os.path.exists(_CONFIG_FILE):
+    with open(_CONFIG_FILE, "w") as f:
+        data: Dict[str, Any] = {"chains": []}
+        json.dump(data, f, indent=4)
+
+
+class ConfigFile:
+    """Helper class for working with the config file."""
+
+    def __init__(self: ConfigFile, data: Dict[str, Any]) -> None:
+        """
+        Initialize a ConfigFile object.
+
+        Args:
+            data: The dictionary with the config data.
+        """
+        self.chains = data["chains"]
+
+    @classmethod
+    def from_file(cls: Type[ConfigFile]) -> ConfigFile:
+        """
+        Initialize a ConfigFile object from a JSON file.
+
+        Returns:
+            The ConfigFile object.
+        """
+        with open(_CONFIG_FILE) as f:
+            data = json.load(f)
+            return cls(data)
+
+    def to_dict(self: ConfigFile) -> Dict[str, Any]:
+        """
+        Convert a ConfigFile object back to a dictionary.
+
+        Returns:
+            A dictionary representing the data in the object.
+        """
+        return {"chains": self.chains}
+
+    def write_to_file(self: ConfigFile) -> None:
+        """Write the ConfigFile data to file."""
+        with open(_CONFIG_FILE, "w") as f:
+            json.dump(self.to_dict(), f, indent=4)
+
+
+def _get_config() -> ConfigFile:
+    return ConfigFile.from_file()
+
+
+def add_chain(chain_data: Dict[str, Any]) -> None:
+    """
+    Add a chain's data to the config file.
+
+    Args:
+        chain_data: The data of the chain to add.
+    """
+    conf = _get_config()
+    conf.chains.append(chain_data)
+    conf.write_to_file()

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -20,18 +20,21 @@ def add_chain(chain_data: ChainData) -> None:
     conf.write_to_file()
 
 
-def check_chain_exists(chain_name: str) -> bool:
+def check_chain_exists(chain_name: str, chain_config: str) -> bool:
     """
-    Check if a chain with a given name is already running.
+    Check if a chain with a given name or config is already running.
 
     Args:
         chain_name: The name of the chain to check.
+        chain_config: The name of the config to check.
 
     Returns:
-        Whether there is already a chain running with that name.
+        Whether there is already a chain running with that name or config.
     """
     conf = _get_config()
     for chain in conf.chains:
         if chain["name"] == chain_name:
+            return True
+        if chain["config"] == chain_config:
             return True
     return False

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -18,3 +18,20 @@ def add_chain(chain_data: ChainData) -> None:
     conf = _get_config()
     conf.chains.append(chain_data)
     conf.write_to_file()
+
+
+def check_chain_exists(chain_name: str) -> bool:
+    """
+    Check if a chain with a given name is already running.
+
+    Args:
+        chain_name: The name of the chain to check.
+
+    Returns:
+        Whether there is already a chain running with that name.
+    """
+    conf = _get_config()
+    for chain in conf.chains:
+        if chain["name"] == chain_name:
+            return True
+    return False

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -1,0 +1,21 @@
+"""Utils for working with the config file."""
+
+from typing import Any, Dict
+
+from sidechain_cli.utils.config_file import ConfigFile
+
+
+def _get_config() -> ConfigFile:
+    return ConfigFile.from_file()
+
+
+def add_chain(chain_data: Dict[str, Any]) -> None:
+    """
+    Add a chain's data to the config file.
+
+    Args:
+        chain_data: The data of the chain to add.
+    """
+    conf = _get_config()
+    conf.chains.append(chain_data)
+    conf.write_to_file()

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -1,15 +1,14 @@
 """Utils for working with the config file."""
 
-from typing import Any, Dict
-
 from sidechain_cli.utils.config_file import ConfigFile
+from sidechain_cli.utils.types import ChainData
 
 
 def _get_config() -> ConfigFile:
     return ConfigFile.from_file()
 
 
-def add_chain(chain_data: Dict[str, Any]) -> None:
+def add_chain(chain_data: ChainData) -> None:
     """
     Add a chain's data to the config file.
 

--- a/sidechain_cli/utils/types.py
+++ b/sidechain_cli/utils/types.py
@@ -1,0 +1,12 @@
+"""Helper types."""
+
+from typing import TypedDict
+
+
+class ChainData(TypedDict):
+    """Helper type for chain data stored in the config file."""
+
+    name: str
+    rippled: str
+    config: str
+    pid: int


### PR DESCRIPTION
## High Level Overview of Change

This PR uses `~/.config/sidechain-cli/config.json` to store data that needs to be persisted between calls to the CLI (such as which nodes are currently running). It adds chains that have been started to that config file, checking that there isn't already a chain with that name.

### Context of Change

This allows us to persist data between calls to the CLI, so we know what's running and can manipulate them.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
