### PR TITLE
feat: implement `stop` and `restart` commands for chains

### DIFF
--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -61,6 +61,7 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
     if verbose:
         print(f"Starting server {name}...")
 
+    # create output file for easier debug purposes
     output_file = f"{CONFIG_FOLDER}/{name}.out"
     if not os.path.exists(output_file):
         # initialize file if it doesn't exist
@@ -80,12 +81,15 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         "pid": pid,
     }
 
+    # check if rippled actually started up correctly
     time.sleep(0.3)
     if process.poll() is not None:
         print("ERROR")
         with open(output_file) as f:
             print(f.read())
         return
+
+    # add chain to config file
     add_chain(chain_data)
     if verbose:
         print(f"started rippled at `{rippled}` with config `{config}`", flush=True)

--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -59,7 +59,7 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         return
     to_run = [rippled, "--conf", config, "-a", "--silent"]
     if verbose:
-        print("Starting server...")
+        print(f"Starting server {name}...")
 
     output_file = f"{CONFIG_FOLDER}/{name}.out"
     if not os.path.exists(output_file):
@@ -88,7 +88,8 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         return
     add_chain(chain_data)
     if verbose:
-        print(f"started rippled: {rippled} PID: {pid}", flush=True)
+        print(f"started rippled at `{rippled}` with config `{config}`", flush=True)
+        print(f"PID: {pid}", flush=True)
 
 
 @click.command(name="stop")
@@ -119,6 +120,9 @@ def stop_chain(
         chains = config.chains
     else:
         chains = [chain for chain in config.chains if chain["name"] == name]
+    if verbose:
+        chain_names = ",".join([chain["name"] for chain in chains])
+        print(f"Shutting down: {chain_names}")
 
     fout = open(os.devnull, "w")
     for chain in chains:

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -1,6 +1,19 @@
 """Util methods for the sidechain CLI."""
 
-from sidechain_cli.utils.config_utils import add_chain, check_chain_exists
+from sidechain_cli.utils.config_file import CONFIG_FOLDER
+from sidechain_cli.utils.config_utils import (
+    add_chain,
+    check_chain_exists,
+    get_config,
+    remove_chain,
+)
 from sidechain_cli.utils.types import ChainData
 
-__all__ = ["add_chain", "check_chain_exists", "ChainData"]
+__all__ = [
+    "add_chain",
+    "check_chain_exists",
+    "get_config",
+    "remove_chain",
+    "ChainData",
+    "CONFIG_FOLDER",
+]

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -9,13 +9,13 @@ from typing import Any, Dict, Type
 
 _HOME = str(Path.home())
 
-_CONFIG_FOLDER = os.path.join(_HOME, ".config", "sidechain-cli")
+CONFIG_FOLDER = os.path.join(_HOME, ".config", "sidechain-cli")
 
 # ~/.config/sidechain-cli/config.json
-_CONFIG_FILE = os.path.join(_CONFIG_FOLDER, "config.json")
+_CONFIG_FILE = os.path.join(CONFIG_FOLDER, "config.json")
 
 # Initialize config file
-Path(_CONFIG_FOLDER).mkdir(parents=True, exist_ok=True)
+Path(CONFIG_FOLDER).mkdir(parents=True, exist_ok=True)
 if not os.path.exists(_CONFIG_FILE):
     with open(_CONFIG_FILE, "w") as f:
         data: Dict[str, Any] = {"chains": []}

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -1,10 +1,18 @@
 """Utils for working with the config file."""
 
+from typing import Optional
+
 from sidechain_cli.utils.config_file import ConfigFile
 from sidechain_cli.utils.types import ChainData
 
 
-def _get_config() -> ConfigFile:
+def get_config() -> ConfigFile:
+    """
+    Get the config file.
+
+    Returns:
+        The config file, as a ConfigFile object.
+    """
     return ConfigFile.from_file()
 
 
@@ -15,7 +23,7 @@ def add_chain(chain_data: ChainData) -> None:
     Args:
         chain_data: The data of the chain to add.
     """
-    conf = _get_config()
+    conf = get_config()
     conf.chains.append(chain_data)
     conf.write_to_file()
 
@@ -31,10 +39,33 @@ def check_chain_exists(chain_name: str, chain_config: str) -> bool:
     Returns:
         Whether there is already a chain running with that name or config.
     """
-    conf = _get_config()
+    conf = get_config()
     for chain in conf.chains:
         if chain["name"] == chain_name:
             return True
         if chain["config"] == chain_config:
             return True
     return False
+
+
+def remove_chain(name: Optional[str] = None, remove_all: bool = False) -> None:
+    """
+    Remove a chain's data to the config file.
+
+    Args:
+        name: The data of the chain to remove.
+        remove_all: Whether to remove all of the chains.
+
+    Raises:
+        Exception: If `name` is `None` and `remove_all` is `False`.
+    """
+    if name is None and remove_all is False:
+        raise Exception(
+            "Cannot remove chain if name is `None` and remove_all is `False`."
+        )
+    conf = get_config()
+    if remove_all:
+        conf.chains = []
+    else:
+        conf.chains = [chain for chain in conf.chains if chain["name"] != name]
+    conf.write_to_file()


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a new feature. Users can now stop and restart rippled nodes from the sidechain CLI. It also adds a check that rippled actually properly started up when running the `start` command.

### Context of Change

Better node handling

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
