### PR TITLE
feat: add the ability to start a witness node

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
-    "esbonio.sphinx.confDir": "${workspaceFolder}/docs"
+    "esbonio.sphinx.confDir": "${workspaceFolder}/docs",
+    "python.linting.mypyEnabled": true,
+    "mypy.runUsingActiveInterpreter": true,
 }

--- a/sidechain_cli/chain/config.py
+++ b/sidechain_cli/chain/config.py
@@ -10,6 +10,9 @@ from sidechain_cli.utils import get_config
 def list_chains() -> None:
     """Get a list of running rippled nodes."""  # noqa: D301
     config = get_config()
+    if len(config.chains) == 0:
+        print("No chains running.")
+        return
     print(
         tabulate(
             config.chains,

--- a/sidechain_cli/chain/config.py
+++ b/sidechain_cli/chain/config.py
@@ -8,7 +8,7 @@ from sidechain_cli.utils import get_config
 
 @click.command(name="list")
 def list_chains() -> None:
-    """Get a list of running rippled nodes."""  # noqa: D301
+    """Get a list of running rippled nodes."""
     config = get_config()
     if len(config.chains) == 0:
         print("No chains running.")

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -3,17 +3,22 @@
 from sidechain_cli.utils.config_file import CONFIG_FOLDER
 from sidechain_cli.utils.config_utils import (
     add_chain,
+    add_witness,
     check_chain_exists,
+    check_witness_exists,
     get_config,
     remove_chain,
 )
-from sidechain_cli.utils.types import ChainData
+from sidechain_cli.utils.types import ChainData, WitnessData
 
 __all__ = [
     "add_chain",
+    "add_witness",
     "check_chain_exists",
+    "check_witness_exists",
     "get_config",
     "remove_chain",
     "ChainData",
+    "WitnessData",
     "CONFIG_FOLDER",
 ]

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -8,6 +8,7 @@ from sidechain_cli.utils.config_utils import (
     check_witness_exists,
     get_config,
     remove_chain,
+    remove_witness,
 )
 from sidechain_cli.utils.types import ChainData, WitnessData
 
@@ -18,6 +19,7 @@ __all__ = [
     "check_witness_exists",
     "get_config",
     "remove_chain",
+    "remove_witness",
     "ChainData",
     "WitnessData",
     "CONFIG_FOLDER",

--- a/sidechain_cli/utils/config_file.py
+++ b/sidechain_cli/utils/config_file.py
@@ -18,7 +18,7 @@ _CONFIG_FILE = os.path.join(CONFIG_FOLDER, "config.json")
 Path(CONFIG_FOLDER).mkdir(parents=True, exist_ok=True)
 if not os.path.exists(_CONFIG_FILE):
     with open(_CONFIG_FILE, "w") as f:
-        data: Dict[str, Any] = {"chains": []}
+        data: Dict[str, Any] = {"chains": [], "witnesses": []}
         json.dump(data, f, indent=4)
 
 # TODO: consider having separate JSONs for each node type
@@ -36,6 +36,7 @@ class ConfigFile:
             data: The dictionary with the config data.
         """
         self.chains = data["chains"]
+        self.witnesses = data["witnesses"]
 
     @classmethod
     def from_file(cls: Type[ConfigFile]) -> ConfigFile:
@@ -56,7 +57,7 @@ class ConfigFile:
         Returns:
             A dictionary representing the data in the object.
         """
-        return {"chains": self.chains}
+        return {"chains": self.chains, "witnesses": self.witnesses}
 
     def write_to_file(self: ConfigFile) -> None:
         """Write the ConfigFile data to file."""

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 from sidechain_cli.utils.config_file import ConfigFile
-from sidechain_cli.utils.types import ChainData
+from sidechain_cli.utils.types import ChainData, WitnessData
 
 
 def get_config() -> ConfigFile:
@@ -14,18 +14,6 @@ def get_config() -> ConfigFile:
         The config file, as a ConfigFile object.
     """
     return ConfigFile.from_file()
-
-
-def add_chain(chain_data: ChainData) -> None:
-    """
-    Add a chain's data to the config file.
-
-    Args:
-        chain_data: The data of the chain to add.
-    """
-    conf = get_config()
-    conf.chains.append(chain_data)
-    conf.write_to_file()
 
 
 def check_chain_exists(chain_name: str, chain_config: str) -> bool:
@@ -48,6 +36,38 @@ def check_chain_exists(chain_name: str, chain_config: str) -> bool:
     return False
 
 
+def check_witness_exists(witness_name: str, witness_config: str) -> bool:
+    """
+    Check if a witness with a given name or config is already running.
+
+    Args:
+        witness_name: The name of the witness to check.
+        witness_config: The name of the config to check.
+
+    Returns:
+        Whether there is already a witness running with that name or config.
+    """
+    conf = get_config()
+    for witness in conf.witnesses:
+        if witness["name"] == witness_name:
+            return True
+        if witness["config"] == witness_config:
+            return True
+    return False
+
+
+def add_chain(chain_data: ChainData) -> None:
+    """
+    Add a chain's data to the config file.
+
+    Args:
+        chain_data: The data of the chain to add.
+    """
+    conf = get_config()
+    conf.chains.append(chain_data)
+    conf.write_to_file()
+
+
 def remove_chain(name: Optional[str] = None, remove_all: bool = False) -> None:
     """
     Remove a chain's data to the config file.
@@ -68,4 +88,16 @@ def remove_chain(name: Optional[str] = None, remove_all: bool = False) -> None:
         conf.chains = []
     else:
         conf.chains = [chain for chain in conf.chains if chain["name"] != name]
+    conf.write_to_file()
+
+
+def add_witness(witness_data: WitnessData) -> None:
+    """
+    Add a witness's data to the config file.
+
+    Args:
+        witness_data: The data of the witness to add.
+    """
+    conf = get_config()
+    conf.witnesses.append(witness_data)
     conf.write_to_file()

--- a/sidechain_cli/utils/config_utils.py
+++ b/sidechain_cli/utils/config_utils.py
@@ -101,3 +101,28 @@ def add_witness(witness_data: WitnessData) -> None:
     conf = get_config()
     conf.witnesses.append(witness_data)
     conf.write_to_file()
+
+
+def remove_witness(name: Optional[str] = None, remove_all: bool = False) -> None:
+    """
+    Remove a witness's data to the config file.
+
+    Args:
+        name: The data of the witness to remove.
+        remove_all: Whether to remove all of the witnesses.
+
+    Raises:
+        Exception: If `name` is `None` and `remove_all` is `False`.
+    """
+    if name is None and remove_all is False:
+        raise Exception(
+            "Cannot remove witness if name is `None` and remove_all is `False`."
+        )
+    conf = get_config()
+    if remove_all:
+        conf.witnesses = []
+    else:
+        conf.witnesses = [
+            witness for witness in conf.witnesses if witness["name"] != name
+        ]
+    conf.write_to_file()

--- a/sidechain_cli/utils/types.py
+++ b/sidechain_cli/utils/types.py
@@ -10,3 +10,12 @@ class ChainData(TypedDict):
     rippled: str
     config: str
     pid: int
+
+
+class WitnessData(TypedDict):
+    """Helper type for witness data stored in the config file."""
+
+    name: str
+    witnessd: str
+    config: str
+    pid: int

--- a/sidechain_cli/witness/config.py
+++ b/sidechain_cli/witness/config.py
@@ -1,9 +1,22 @@
 """Config-related witness commands."""
 
 import click
+from tabulate import tabulate
+
+from sidechain_cli.utils import get_config
 
 
 @click.command(name="list")
 def list_witnesses() -> None:
-    """Get a list of running witness nodes."""  # noqa: D301
-    print("Insert list of witnesses here")
+    """Get a list of running witness nodes."""
+    config = get_config()
+    if len(config.witnesses) == 0:
+        print("No witnesses running.")
+        return
+    print(
+        tabulate(
+            config.witnesses,
+            headers="keys",
+            tablefmt="presto",
+        )
+    )

--- a/sidechain_cli/witness/start.py
+++ b/sidechain_cli/witness/start.py
@@ -133,8 +133,10 @@ def stop_witness(
         name = witness["name"]
         witnessd = witness["witnessd"]
         config = witness["config"]
-        to_run = [witnessd, "--conf", config, "stop"]
-        subprocess.call(to_run, stdout=fout, stderr=subprocess.STDOUT)
+        to_run = [witnessd, "--config", config, "stop"]
+        print(to_run, fout)
+        print("NOTE: You need to kill the witness server by hand.")
+        # subprocess.call(to_run, stdout=fout, stderr=subprocess.STDOUT)
         if verbose:
             print(f"Stopped {name}")
 

--- a/sidechain_cli/witness/start.py
+++ b/sidechain_cli/witness/start.py
@@ -1,6 +1,7 @@
 """CLI functions for starting/stopping a witness node."""
 
 import os
+import signal
 import subprocess
 import time
 from typing import Optional
@@ -128,15 +129,15 @@ def stop_witness(
         witness_names = ",".join([witness["name"] for witness in witnesses])
         print(f"Shutting down: {witness_names}")
 
-    fout = open(os.devnull, "w")
+    # fout = open(os.devnull, "w")
     for witness in witnesses:
-        name = witness["name"]
-        witnessd = witness["witnessd"]
-        config = witness["config"]
-        to_run = [witnessd, "--config", config, "stop"]
-        print(to_run, fout)
-        print("NOTE: You need to kill the witness server by hand.")
+        # name = witness["name"]
+        # witnessd = witness["witnessd"]
+        # config = witness["config"]
+        # to_run = [witnessd, "--config", config, "stop"]
         # subprocess.call(to_run, stdout=fout, stderr=subprocess.STDOUT)
+        pid = witness["pid"]
+        os.kill(pid, signal.SIGINT)
         if verbose:
             print(f"Stopped {name}")
 

--- a/sidechain_cli/witness/start.py
+++ b/sidechain_cli/witness/start.py
@@ -1,43 +1,97 @@
 """CLI functions for starting/stopping a witness node."""
 
+import os
+import subprocess
+import time
 from typing import Optional
 
 import click
 
+from sidechain_cli.utils import (
+    CONFIG_FOLDER,
+    WitnessData,
+    add_witness,
+    check_witness_exists,
+)
+
 
 @click.command(name="start")
 @click.option(
-    "--name", help="The name of the witness (used for differentiation purposes)."
+    "--name",
+    required=True,
+    prompt=True,
+    help="The name of the witness (used for differentiation purposes).",
 )
 @click.option(
-    "--witness",
+    "--witnessd",
     required=True,
     prompt=True,
     type=click.Path(exists=True),
-    help="The filepath to the witness executable.",
+    help="The filepath to the witnessd executable.",
 )
 @click.option(
     "--config",
     required=True,
     prompt=True,
     type=click.Path(exists=True),
-    help="The filepath to the witness config file.",
+    help="The filepath to the witnessd config file.",
 )
 @click.option(
     "--verbose", is_flag=True, help="Whether or not to print more verbose information."
 )
-def start_witness(name: str, witness: str, config: str, verbose: bool = False) -> None:
+def start_witness(name: str, witnessd: str, config: str, verbose: bool = False) -> None:
     """
     Start a standalone node of witness.
     \f
 
     Args:
         name: The name of the witness (used for differentiation purposes).
-        witness: The filepath to the witness executable.
-        config: The filepath to the witness config file.
+        witnessd: The filepath to the witness executable.
+        config: The filepath to the witnessd config file.
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
-    print(name, witness, config, verbose)
+    witnessd = os.path.abspath(witnessd)
+    config = os.path.abspath(config)
+    if check_witness_exists(name, config):
+        print("Error: Witness already running with that name or config.")
+        return
+    to_run = [witnessd, "--config", config]
+    if verbose:
+        print(f"Starting server {name}...")
+
+    # create output file for easier debug purposes
+    output_file = f"{CONFIG_FOLDER}/{name}.out"
+    if not os.path.exists(output_file):
+        # initialize file if it doesn't exist
+        with open(output_file, "w") as f:
+            f.write("")
+    fout = open(output_file, "w")
+
+    process = subprocess.Popen(
+        to_run, stdout=fout, stderr=subprocess.STDOUT, close_fds=True
+    )
+    pid = process.pid
+
+    witness_data: WitnessData = {
+        "name": name,
+        "witnessd": witnessd,
+        "config": config,
+        "pid": pid,
+    }
+
+    # check if witnessd actually started up correctly
+    time.sleep(0.3)
+    if process.poll() is not None:
+        print("ERROR")
+        with open(output_file) as f:
+            print(f.read())
+        return
+
+    # add witness to config file
+    add_witness(witness_data)
+    if verbose:
+        print(f"started witnessd at `{witnessd}` with config `{config}`", flush=True)
+        print(f"PID: {pid}", flush=True)
 
 
 @click.command(name="stop")


### PR DESCRIPTION
## High Level Overview of Change

This PR implements the methods to start, stop, and restart a witness server. There isn't currently a way to stop a witness server from the command line, so that's done with a SIGINT to the process.

### Context of Change

working with the witness nodes

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
