### PR TITLE
feat: add ip/port info to the chain and witness config

### DIFF
--- a/sidechain_cli/chain/start.py
+++ b/sidechain_cli/chain/start.py
@@ -10,6 +10,7 @@ import click
 from sidechain_cli.utils import (
     CONFIG_FOLDER,
     ChainData,
+    RippledConfig,
     add_chain,
     check_chain_exists,
     get_config,
@@ -54,6 +55,7 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
     """  # noqa: D301
     rippled = os.path.abspath(rippled)
     config = os.path.abspath(config)
+    config_object = RippledConfig(file_name=config)
     if check_chain_exists(name, config):
         print("Error: Chain already running with that name or config.")
         return
@@ -79,6 +81,10 @@ def start_chain(name: str, rippled: str, config: str, verbose: bool = False) -> 
         "rippled": rippled,
         "config": config,
         "pid": pid,
+        "ws_ip": config_object.port_ws_admin_local.ip,
+        "ws_port": int(config_object.port_ws_admin_local.port),
+        "http_ip": config_object.port_rpc_admin_local.ip,
+        "http_port": int(config_object.port_rpc_admin_local.port),
     }
 
     # check if rippled actually started up correctly

--- a/sidechain_cli/utils/__init__.py
+++ b/sidechain_cli/utils/__init__.py
@@ -10,6 +10,7 @@ from sidechain_cli.utils.config_utils import (
     remove_chain,
     remove_witness,
 )
+from sidechain_cli.utils.rippled_config import RippledConfig
 from sidechain_cli.utils.types import ChainData, WitnessData
 
 __all__ = [
@@ -23,4 +24,5 @@ __all__ = [
     "ChainData",
     "WitnessData",
     "CONFIG_FOLDER",
+    "RippledConfig",
 ]

--- a/sidechain_cli/utils/rippled_config.py
+++ b/sidechain_cli/utils/rippled_config.py
@@ -1,0 +1,173 @@
+"""A computer-readable representation of a rippled.cfg config file."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Type
+
+
+class _Section:
+    """
+    A computer-readable representation of a section of a rippled.cfg config file.
+
+    e.g.
+    [section_name]
+    section_key_1=value_1
+    section_key_2=value_2
+    """
+
+    @classmethod
+    def section_header(cls: Type[_Section], line: str) -> Optional[str]:
+        """
+        If the line is a section header, return the section name. Otherwise return None.
+
+        Args:
+            line: The line of the section.
+
+        Returns:
+            The section name, if it exists. Else, none.
+        """
+        if line.startswith("[") and line.endswith("]"):
+            return line[1:-1]
+        return None
+
+    def __init__(self: _Section, name: str) -> None:
+        """
+        Initialize a section of the config file.
+
+        Args:
+            name: The name of the section.
+        """
+        self._set_init(True)
+        self._name = name
+        # lines contains all non key-value pairs
+        self._lines: List[str] = []
+        self._kv_pairs: Dict[str, str] = {}
+        self._set_init(False)
+
+    def get_name(self: _Section) -> str:
+        return self._name
+
+    def add_line(self: _Section, line: str) -> None:
+        s = line.split("=")
+        if len(s) == 2:
+            self._kv_pairs[s[0].strip()] = s[1].strip()
+        else:
+            self._lines.append(line)
+
+    def get_lines(self: _Section) -> List[str]:
+        return self._lines
+
+    def get_line(self: _Section) -> Optional[str]:
+        if len(self._lines) > 0:
+            return self._lines[0]
+        return None
+
+    def __getstate__(self: _Section) -> Dict[str, Any]:
+        return vars(self)
+
+    def __setstate__(self: _Section, state: Dict[str, Any]) -> None:
+        vars(self).update(state)
+
+    def _set_init(self: _Section, value: bool) -> None:
+        # turn on/off "init" mode
+        super().__setattr__("init", value)
+
+    def __getattr__(self: _Section, name: str) -> str:
+        try:
+            return self._kv_pairs[name]
+        except KeyError:
+            raise AttributeError(name)
+
+    def __setattr__(self: _Section, name: str, value: str) -> None:
+        if self.init or name in self.__dict__:
+            super().__setattr__(name, value)
+        else:
+            self._kv_pairs[name] = value
+
+
+class RippledConfig:
+    """A computer-readable representation of a rippled.cfg config file."""
+
+    def __init__(self: RippledConfig, *, file_name: str) -> None:
+        """
+        Parse a config file and initialize the RippledConfig object.
+
+        Args:
+            file_name: The name/location of the config file.
+
+        Raises:
+            ValueError: If there is an error in parsing the config file.
+        """
+        # parse the file
+        self._file_name = file_name
+        self._sections: Dict[str, _Section] = {}
+
+        cur_section = None
+        with open(file_name) as f:
+            for n, line in enumerate(f):
+                line = line.strip()
+                if line.startswith("#") or not line:
+                    continue
+                section_name = _Section.section_header(line)
+                if section_name is not None:
+                    if cur_section:
+                        self._add_section(cur_section)
+                    cur_section = _Section(section_name)
+                    continue
+                if cur_section is None:
+                    raise ValueError(
+                        f"Error parsing config file: {file_name} "
+                        f"line_num: {n} line: {line}"
+                    )
+                cur_section.add_line(line)
+
+        if cur_section:
+            self._add_section(cur_section)
+
+    def _add_section(self: RippledConfig, s: _Section) -> None:
+        self._sections[s.get_name()] = s
+
+    def get_file_name(self: RippledConfig) -> str:
+        """
+        Get the file name/location of the config file.
+
+        Returns:
+            The config file name/location.
+        """
+        return self._file_name
+
+    def __getstate__(self: RippledConfig) -> Dict[str, Any]:
+        """
+        Get the state of a RippledConfig.
+
+        Returns:
+            The state of the RippledConfig.
+        """
+        return vars(self)
+
+    def __setstate__(self: RippledConfig, state: Dict[str, Any]) -> None:
+        """
+        Set the state of a RippledConfig.
+
+        Args:
+            state: The state to update the object with.
+        """
+        vars(self).update(state)
+
+    def __getattr__(self: RippledConfig, name: str) -> _Section:
+        """
+        Get a section from the RippledConfig, using the syntax `config.section_name`.
+
+        Args:
+            name: Name of the section.
+
+        Returns:
+            The section with the provided name.
+
+        Raises:
+            AttributeError: if a section with the provided name does not exist.
+        """
+        try:
+            return self._sections[name]
+        except KeyError:
+            raise AttributeError(name)

--- a/sidechain_cli/utils/types.py
+++ b/sidechain_cli/utils/types.py
@@ -1,6 +1,6 @@
 """Helper types."""
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 
 class ChainData(TypedDict):
@@ -10,6 +10,10 @@ class ChainData(TypedDict):
     rippled: str
     config: str
     pid: int
+    ws_ip: str
+    ws_port: int
+    http_ip: str
+    http_port: Optional[int]
 
 
 class WitnessData(TypedDict):
@@ -19,3 +23,5 @@ class WitnessData(TypedDict):
     witnessd: str
     config: str
     pid: int
+    ip: str
+    rpc_port: int

--- a/sidechain_cli/utils/types.py
+++ b/sidechain_cli/utils/types.py
@@ -1,6 +1,6 @@
 """Helper types."""
 
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class ChainData(TypedDict):
@@ -13,7 +13,7 @@ class ChainData(TypedDict):
     ws_ip: str
     ws_port: int
     http_ip: str
-    http_port: Optional[int]
+    http_port: int
 
 
 class WitnessData(TypedDict):

--- a/sidechain_cli/witness/start.py
+++ b/sidechain_cli/witness/start.py
@@ -1,5 +1,6 @@
 """CLI functions for starting/stopping a witness node."""
 
+import json
 import os
 import signal
 import subprocess
@@ -55,6 +56,7 @@ def start_witness(name: str, witnessd: str, config: str, verbose: bool = False) 
     """  # noqa: D301
     witnessd = os.path.abspath(witnessd)
     config = os.path.abspath(config)
+
     if check_witness_exists(name, config):
         print("Error: Witness already running with that name or config.")
         return
@@ -74,12 +76,16 @@ def start_witness(name: str, witnessd: str, config: str, verbose: bool = False) 
         to_run, stdout=fout, stderr=subprocess.STDOUT, close_fds=True
     )
     pid = process.pid
+    with open(config) as f:
+        config_json = json.load(f)
 
     witness_data: WitnessData = {
         "name": name,
         "witnessd": witnessd,
         "config": config,
         "pid": pid,
+        "ip": config_json["rpc_endpoint"]["ip"],
+        "rpc_port": config_json["rpc_endpoint"]["port"],
     }
 
     # check if witnessd actually started up correctly


### PR DESCRIPTION
## High Level Overview of Change

This PR adds the HTTP and WS IP and port info to the chain and witness config, so the information is easier to access.

### Context of Change

Ease of access for ip/port info

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
