### PR TITLE
feat: add method to fund accounts in standalone

### DIFF
--- a/sidechain_cli/main.py
+++ b/sidechain_cli/main.py
@@ -4,6 +4,7 @@ import click
 
 from sidechain_cli.bridge import bridge
 from sidechain_cli.chain import chain
+from sidechain_cli.misc.fund import fund_account
 from sidechain_cli.witness import witness
 
 
@@ -16,6 +17,7 @@ def main() -> None:
 main.add_command(chain)
 main.add_command(witness)
 main.add_command(bridge)
+main.add_command(fund_account)
 
 
 if __name__ == "__main__":

--- a/sidechain_cli/misc/__init__.py
+++ b/sidechain_cli/misc/__init__.py
@@ -1,0 +1,1 @@
+"""Misc methods."""

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -1,1 +1,66 @@
 """Fund an account from the genesis account."""
+
+from pprint import pprint
+from typing import cast
+
+import click
+from xrpl.clients import JsonRpcClient
+from xrpl.models import AccountInfo, GenericRequest, Payment
+from xrpl.transaction import safe_sign_and_autofill_transaction, submit_transaction
+from xrpl.utils import xrp_to_drops
+from xrpl.wallet import Wallet
+
+from sidechain_cli.utils import ChainData, get_config
+
+
+def _get_chain(name: str) -> ChainData:
+    config = get_config()
+    for chain in config.chains:
+        if chain["name"] == name:
+            return cast(ChainData, chain)
+    raise Exception(f"No chain with name {name}.")
+
+
+@click.command(name="fund")
+@click.option(
+    "--chain",
+    required=True,
+    prompt=True,
+    type=str,
+    help="The chain to fund an account on.",
+)
+@click.option(
+    "--account",
+    required=True,
+    prompt=True,
+    type=str,
+    help="The account to fund.",
+)
+@click.option(
+    "--verbose", is_flag=True, help="Whether or not to print more verbose information."
+)
+def fund_account(chain: str, account: str, verbose: bool = False) -> None:
+    """
+    Fund an account from the genesis account. Only works on a normal standalone rippled
+    node.
+    \f
+
+    Args:
+        chain: The chain to fund an account on.
+        account: The chain to fund an account on.
+        verbose: Whether or not to print more verbose information.
+    """  # noqa: D301
+    chain_config = _get_chain(chain)
+    client = JsonRpcClient(
+        f"http://{chain_config['http_ip']}:{chain_config['http_port']}"
+    )
+
+    wallet = Wallet("snoPBrXtMeMyMHUVTgbuqAfg1SUTb", 0)
+    payment = Payment(
+        account=wallet.classic_address, destination=account, amount=xrp_to_drops(1000)
+    )
+    signed = safe_sign_and_autofill_transaction(payment, wallet, client)
+    submit_transaction(signed, client)
+    client.request(GenericRequest(method="ledger_accept"))
+    if verbose:
+        pprint(client.request(AccountInfo(account=account)).result)

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -5,8 +5,7 @@ from typing import cast
 
 import click
 from xrpl.clients import JsonRpcClient
-from xrpl.models import AccountInfo, GenericRequest, Payment
-from xrpl.transaction import safe_sign_and_autofill_transaction, submit_transaction
+from xrpl.models import AccountInfo, GenericRequest, Payment, SignAndSubmit
 from xrpl.utils import xrp_to_drops
 from xrpl.wallet import Wallet
 
@@ -59,8 +58,7 @@ def fund_account(chain: str, account: str, verbose: bool = False) -> None:
     payment = Payment(
         account=wallet.classic_address, destination=account, amount=xrp_to_drops(1000)
     )
-    signed = safe_sign_and_autofill_transaction(payment, wallet, client)
-    submit_transaction(signed, client)
+    client.request(SignAndSubmit(transaction=payment, secret=wallet.seed))
     client.request(GenericRequest(method="ledger_accept"))
     if verbose:
         pprint(client.request(AccountInfo(account=account)).result)

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -1,0 +1,1 @@
+"""Fund an account from the genesis account."""


### PR DESCRIPTION
## High Level Overview of Change

This PR adds a new feature, `sidechain-cli fund`. It allows users to fund accounts in standalone mode from the genesis account.

### Context of Change

It was annoying to have to do it by hand.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
