### PR TITLE
feat: add env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@
 ```bash
 pip install xrpl-sidechain-cli
 ```
+
+Install rippled and the xbridge witness.
+
+## Get started
+
+```bash
+export XCHAIN_CONFIG_DIR={filepath where you want your config files stored}
+export RIPPLED_EXE={rippled exe filepath}
+export WITNESSD_EXE={witnessd exe filepath}
+sidechain-cli server create-config all
+sidechain-cli server start-all
+sidechain-cli server list
+```
+
+To stop the servers:
+```bash
+sidechain-cli server stop --all
+```

--- a/sidechain_cli/server/__init__.py
+++ b/sidechain_cli/server/__init__.py
@@ -5,7 +5,12 @@ import click
 from sidechain_cli.server.config import create_server_configs
 from sidechain_cli.server.list import list_servers
 from sidechain_cli.server.request import get_server_status, request_server
-from sidechain_cli.server.start import restart_server, start_server, stop_server
+from sidechain_cli.server.start import (
+    restart_server,
+    start_all_servers,
+    start_server,
+    stop_server,
+)
 
 
 @click.group()
@@ -15,6 +20,7 @@ def server() -> None:
 
 
 server.add_command(start_server, name="start")
+server.add_command(start_all_servers, name="start-all")
 server.add_command(stop_server, name="stop")
 server.add_command(restart_server, name="restart")
 

--- a/sidechain_cli/server/config/config.py
+++ b/sidechain_cli/server/config/config.py
@@ -239,6 +239,7 @@ def generate_bootstrap(
     envvar="XCHAIN_CONFIG_DIR",
     required=True,
     prompt=True,
+    type=click.Path(),
     help="The folder in which to store config files.",
 )
 @click.option(

--- a/sidechain_cli/server/config/config.py
+++ b/sidechain_cli/server/config/config.py
@@ -6,85 +6,20 @@ import os
 from pathlib import Path
 from pprint import pprint
 from sys import platform
-from typing import Any, Dict, Tuple, Type
+from typing import Any, Dict, Tuple
 
 import click
 from jinja2 import Environment, FileSystemLoader
 from xrpl import CryptoAlgorithm
 from xrpl.wallet import Wallet
 
+from sidechain_cli.server.config.ports import Ports
+
 JINJA_ENV = Environment(
-    loader=FileSystemLoader(searchpath="./sidechain_cli/server/config/templates")
+    loader=FileSystemLoader(
+        searchpath=os.path.join(*os.path.split(__file__)[:-1], "templates")
+    )
 )
-
-
-class Ports:
-    """
-    Port numbers for various services.
-    Port numbers differ by cfg_index so different configs can run
-    at the same time without interfering with each other.
-    """
-
-    # TODO: somehow keep track of ports in the CLI config file
-
-    peer_port_base = 51235
-    http_admin_port_base = 5005
-    ws_public_port_base = 6005
-
-    def __init__(
-        self: Ports,
-        peer_port: int,
-        http_admin_port: int,
-        ws_public_port: int,
-        ws_admin_port: int,
-    ) -> None:
-        """
-        Initialize a Ports.
-
-        Args:
-            peer_port: The peer port of the node. Only needed for a local node.
-            http_admin_port: The admin HTTP port of the node. Only needed for a local
-                node.
-            ws_public_port: The public WS port of the node.
-            ws_admin_port: The admin WS port of the node. Only needed for a local node.
-        """
-        self.peer_port = peer_port
-        self.http_admin_port = http_admin_port
-        self.ws_public_port = ws_public_port
-        self.ws_admin_port = ws_admin_port
-
-    @classmethod
-    def generate(cls: Type[Ports], cfg_index: int) -> Ports:
-        """
-        Generate a Ports with the given config index.
-
-        Args:
-            cfg_index: The port number the set of ports should start at.
-
-        Returns:
-            A Ports with the ports all set up based on the config index.
-        """
-        return cls(
-            Ports.peer_port_base + cfg_index,
-            Ports.http_admin_port_base + cfg_index,
-            Ports.ws_public_port_base + (2 * cfg_index),
-            # note admin port uses public port base
-            Ports.ws_public_port_base + (2 * cfg_index) + 1,
-        )
-
-    def to_dict(self: Ports) -> Dict[str, int]:
-        """
-        Convert the Ports to a dictionary.
-
-        Returns:
-            The ports represented by the Ports, in dictionary form.
-        """
-        return {
-            "peer_port": self.peer_port,
-            "http_admin_port": self.http_admin_port,
-            "ws_public_port": self.ws_public_port,
-            "ws_admin_port": self.ws_admin_port,
-        }
 
 
 # render a Jinja template and dump it into a file

--- a/sidechain_cli/server/config/ports.py
+++ b/sidechain_cli/server/config/ports.py
@@ -1,0 +1,74 @@
+"""Port numbers for various services."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+
+class Ports:
+    """
+    Port numbers for various services.
+    Port numbers differ by cfg_index so different configs can run
+    at the same time without interfering with each other.
+    """
+
+    # TODO: somehow keep track of ports in the CLI config file
+
+    peer_port_base = 51235
+    http_admin_port_base = 5005
+    ws_public_port_base = 6005
+
+    def __init__(
+        self: Ports,
+        peer_port: int,
+        http_admin_port: int,
+        ws_public_port: int,
+        ws_admin_port: int,
+    ) -> None:
+        """
+        Initialize a Ports.
+
+        Args:
+            peer_port: The peer port of the node. Only needed for a local node.
+            http_admin_port: The admin HTTP port of the node. Only needed for a local
+                node.
+            ws_public_port: The public WS port of the node.
+            ws_admin_port: The admin WS port of the node. Only needed for a local node.
+        """
+        self.peer_port = peer_port
+        self.http_admin_port = http_admin_port
+        self.ws_public_port = ws_public_port
+        self.ws_admin_port = ws_admin_port
+
+    @classmethod
+    def generate(cls: Type[Ports], cfg_index: int) -> Ports:
+        """
+        Generate a Ports with the given config index.
+
+        Args:
+            cfg_index: The port number the set of ports should start at.
+
+        Returns:
+            A Ports with the ports all set up based on the config index.
+        """
+        return cls(
+            Ports.peer_port_base + cfg_index,
+            Ports.http_admin_port_base + cfg_index,
+            Ports.ws_public_port_base + (2 * cfg_index),
+            # note admin port uses public port base
+            Ports.ws_public_port_base + (2 * cfg_index) + 1,
+        )
+
+    def to_dict(self: Ports) -> Dict[str, int]:
+        """
+        Convert the Ports to a dictionary.
+
+        Returns:
+            The ports represented by the Ports, in dictionary form.
+        """
+        return {
+            "peer_port": self.peer_port,
+            "http_admin_port": self.http_admin_port,
+            "ws_public_port": self.ws_public_port,
+            "ws_admin_port": self.ws_admin_port,
+        }

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -172,7 +172,8 @@ def start_all_servers(
 ) -> None:
     """
     Start all the servers (both rippled and witnesses) that have config files in the
-    config directory.
+    config directory. If there is a rippled.cfg file in the folder, it will start
+    rippled. If there is a witness.json file in the folder, it will start a witness.
     \f
 
     Args:


### PR DESCRIPTION
## High Level Overview of Change

This PR adds environment variable support for the `sidechain-cli server create-config` method (specifically, the config dir param). It also adds a new method, `sidechain-cli server start-all`, which will start all the servers that have configs in the folder (e.g. if the user just used the `create-config` method).

### Context of Change

make it _much_ easier to spin up everything

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Works locally.
