### PR TITLE
ci: cache poetry dependencies

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
@@ -24,11 +24,17 @@ jobs:
         run: |
           python -c "import sys; print(sys.version)"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install poetry
-          poetry install
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Retrieve poetry dependencies from cache
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+
+      - name: Install poetry dependencies
+        run: poetry install
 
       - name: Lint
         run: |


### PR DESCRIPTION
## High Level Overview of Change

This PR caches the poetry dependencies in Github Actions, for a faster CI. It appears to shave about 30-40 seconds off of the amount of time it takes each CI test to run.

### Context of Change

Everyone wants speedy CI

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] CI change

## Test Plan

CI passes and is faster.
