### PR TITLE
feat: add `-vv` support for additional printing to bridge methods

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -173,14 +173,14 @@ pydocstyle = ">=2.1"
 
 [[package]]
 name = "flake8-isort"
-version = "4.1.2.post0"
+version = "4.2.0"
 description = "flake8 plugin that integrates isort ."
 category = "dev"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-flake8 = ">=3.2.1,<5"
+flake8 = ">=3.2.1,<6"
 isort = ">=4.3.5,<6"
 
 [package.extras]
@@ -482,7 +482,7 @@ websockets = {version = "^10.0", markers = "python_version >= \"3.10\" and pytho
 type = "git"
 url = "https://github.com/XRPLF/xrpl-py.git"
 reference = "sidechain-2.5"
-resolved_reference = "dadfa5662d0242155662eebea3f6b204dd483e86"
+resolved_reference = "dc032fa41f3b30f15e371d5090a7210b3324bdcf"
 
 [[package]]
 name = "zipp"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,10 +1,10 @@
 rm ~/.config/sidechain-cli/config.json  # TODO: remove once cleanup is better
 sidechain-cli server start-all
 sidechain-cli server list
-sidechain-cli bridge create --name=bridge --chains mainchain sidechain --witness witness0 --witness witness1 --witness witness2 --witness witness3 --witness witness4
-cat ../sidechain-config/bridge_bootstrap.json | jq .mainchain_door.id | tr -d '"' | sidechain-cli fund --chain mainchain
-sidechain-cli bridge build --bridge bridge --bootstrap ../sidechain-config/bridge_bootstrap.json
-sidechain-cli fund --chain mainchain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-sidechain-cli fund --chain sidechain --account rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi
-sidechain-cli fund --chain sidechain --account rGzx83BVoqTYbGn7tiVAnFw7cbxjin13jL
-sidechain-cli bridge transfer --bridge bridge --src_chain mainchain --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+# sidechain-cli bridge create --name=bridge --chains mainchain sidechain --witness witness0 --witness witness1 --witness witness2 --witness witness3 --witness witness4
+# cat ../sidechain-config/bridge_bootstrap.json | jq .mainchain_door.id | tr -d '"' | sidechain-cli fund --chain mainchain
+# sidechain-cli bridge build --bridge bridge --bootstrap ../sidechain-config/bridge_bootstrap.json
+# sidechain-cli fund --chain mainchain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
+# sidechain-cli fund --chain sidechain --account rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi
+# sidechain-cli fund --chain sidechain --account rGzx83BVoqTYbGn7tiVAnFw7cbxjin13jL
+# sidechain-cli bridge transfer --bridge bridge --src_chain mainchain --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,10 +1,10 @@
 rm ~/.config/sidechain-cli/config.json  # TODO: remove once cleanup is better
 sidechain-cli server start-all
 sidechain-cli server list
-# sidechain-cli bridge create --name=bridge --chains mainchain sidechain --witness witness0 --witness witness1 --witness witness2 --witness witness3 --witness witness4
-# cat ../sidechain-config/bridge_bootstrap.json | jq .mainchain_door.id | tr -d '"' | sidechain-cli fund --chain mainchain
-# sidechain-cli bridge build --bridge bridge --bootstrap ../sidechain-config/bridge_bootstrap.json
-# sidechain-cli fund --chain mainchain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
-# sidechain-cli fund --chain sidechain --account rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi
-# sidechain-cli fund --chain sidechain --account rGzx83BVoqTYbGn7tiVAnFw7cbxjin13jL
-# sidechain-cli bridge transfer --bridge bridge --src_chain mainchain --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose
+sidechain-cli bridge create --name=bridge --chains mainchain sidechain --witness witness0 --witness witness1 --witness witness2 --witness witness3 --witness witness4
+cat ../sidechain-config/bridge_bootstrap.json | jq .mainchain_door.id | tr -d '"' | sidechain-cli fund --chain mainchain
+sidechain-cli bridge build --bridge bridge --bootstrap ../sidechain-config/bridge_bootstrap.json
+sidechain-cli fund --chain mainchain --account raFcdz1g8LWJDJWJE2ZKLRGdmUmsTyxaym
+sidechain-cli fund --chain sidechain --account rJdTJRJZ6GXCCRaamHJgEqVzB7Zy4557Pi
+sidechain-cli fund --chain sidechain --account rGzx83BVoqTYbGn7tiVAnFw7cbxjin13jL
+sidechain-cli bridge transfer --bridge bridge --src_chain mainchain --amount 10000000 --from snqs2zzXuMA71w9isKHPTrvFn1HaJ --to snyEJjY2Xi5Dxdh81Jy9Mj3AiYRQM --verbose

--- a/sidechain_cli/bridge/setup.py
+++ b/sidechain_cli/bridge/setup.py
@@ -1,6 +1,7 @@
 """CLI command for setting up a bridge."""
 
 import json
+from pprint import pprint
 from typing import List, Tuple, cast
 
 import click
@@ -66,7 +67,10 @@ def _str_to_currency(token: str) -> CurrencyDict:
     help="The reward for witnesses providing a signature.",
 )
 @click.option(
-    "--verbose", is_flag=True, help="Whether or not to print more verbose information."
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Whether or not to print more verbose information.",
 )
 def create_bridge(
     name: str,
@@ -119,6 +123,8 @@ def create_bridge(
         "signature_reward": signature_reward,
     }
 
+    if verbose:
+        pprint(bridge_data)
     add_bridge(bridge_data)
 
 
@@ -134,16 +140,20 @@ def create_bridge(
     help="The filepath to the bootstrap config file.",
 )
 @click.option(
-    "--verbose", is_flag=True, help="Whether or not to print more verbose information."
+    "-v",
+    "--verbose",
+    help="Whether or not to print more verbose information. Also supports `-vv`.",
+    count=True,
 )
-def setup_bridge(bridge: str, bootstrap: str, verbose: bool = False) -> None:
+def setup_bridge(bridge: str, bootstrap: str, verbose: int = 0) -> None:
     """
     Set up a bridge between a locking chain and issuing chain.
 
     Args:
         bridge: The bridge to build.
         bootstrap: The filepath to the bootstrap config file.
-        verbose: Whether or not to print more verbose information.
+        verbose: Whether or not to print more verbose information. Add more v's for
+            more verbosity.
     """
     bridge_config = get_config().get_bridge(bridge)
     with open(bootstrap) as f:

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -23,15 +23,10 @@ from sidechain_cli.utils import get_config, submit_tx
 
 
 def _submit_tx(
-    tx: Transaction, client: JsonRpcClient, secret: str, verbose: bool
+    tx: Transaction, client: JsonRpcClient, secret: str, verbose: int
 ) -> Response:
-    if verbose:
-        print(f"submitting tx to {client.url}:")
-        pprint(tx.to_xrpl())
-    result = submit_tx(tx, client, secret)
+    result = submit_tx(tx, client, secret, verbose)
     tx_result = result.result.get("error") or result.result.get("engine_result")
-    if verbose:
-        print(f"Result: {tx_result}")
     if tx_result != "tesSUCCESS":
         raise Exception(
             result.result.get("error_message")
@@ -76,7 +71,10 @@ def _submit_tx(
     help="The seed of the account to transfer to.",
 )
 @click.option(
-    "--verbose", is_flag=True, help="Whether or not to print more verbose information."
+    "-v",
+    "--verbose",
+    count=True,
+    help="Whether or not to print more verbose information. Supports `-vv`.",
 )
 @click.option(
     "--tutorial",
@@ -89,7 +87,7 @@ def send_transfer(
     amount: str,
     from_account: str,
     to_account: str,
-    verbose: bool = False,
+    verbose: int = 0,
     tutorial: bool = False,
 ) -> None:
     """
@@ -101,12 +99,13 @@ def send_transfer(
         amount: The amount to transfer.
         from_account: The seed of the account to transfer from.
         to_account: The seed of the account to transfer to.
-        verbose: Whether or not to print more verbose information.
+        verbose: Whether or not to print more verbose information. Supports `-vv`.
         tutorial: Whether to slow down and explain each step.
 
     Raises:
         Exception: If there is an error with a transaction somewhere along the way.
     """
+    print_level = max(verbose, 1 if tutorial else 0)
     bridge_config = get_config().get_bridge(bridge)
     if src_chain not in bridge_config.chains:
         print(f"Error: {src_chain} not one of the chains in {bridge}.")
@@ -142,9 +141,7 @@ def send_transfer(
         signature_reward=bridge_config.signature_reward,
         other_chain_account=from_wallet.classic_address,
     )
-    seq_num_result = _submit_tx(
-        seq_num_tx, dst_client, to_wallet.seed, verbose or tutorial
-    )
+    seq_num_result = _submit_tx(seq_num_tx, dst_client, to_wallet.seed, print_level)
 
     # extract new sequence number from metadata
     nodes = seq_num_result.result["meta"]["AffectedNodes"]
@@ -168,7 +165,7 @@ def send_transfer(
         xchain_claim_id=xchain_claim_id,
         other_chain_account=to_wallet.classic_address,
     )
-    _submit_tx(commit_tx, src_client, from_wallet.seed, verbose or tutorial)
+    _submit_tx(commit_tx, src_client, from_wallet.seed, print_level)
 
     # TODO: wait for the witnesses to send their attestations (once witnesses send
     # their own)
@@ -200,8 +197,10 @@ def send_transfer(
         }
 
         proof_result = httpx.post(witness_url, json=proof_request).json()
-        if verbose or tutorial:
+        if print_level > 1:
             pprint(proof_result)
+        elif print_level > 0:
+            print(f"Proof from {witness_config.name} successfully received.")
 
         if "error" in proof_result:
             error_message = proof_result["error"]["error"]
@@ -228,12 +227,12 @@ def send_transfer(
             attestation_tx,
             dst_client,
             "snLsJNbh3qQVJuB2FmoGu3SGBENLB",
-            verbose or tutorial,
+            print_level,
         )
     except Exception as e:
         if "No such xchain claim id" not in e.args[0]:
             raise e
-        if verbose or tutorial:
+        if print_level > 0:
             print(
                 "  This means that quorum has already been reached and the funds "
                 "have already been transferred."

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -105,7 +105,7 @@ def send_transfer(
     Raises:
         Exception: If there is an error with a transaction somewhere along the way.
     """
-    print_level = max(verbose, 1 if tutorial else 0)
+    print_level = max(verbose, 2 if tutorial else 0)
     bridge_config = get_config().get_bridge(bridge)
     if src_chain not in bridge_config.chains:
         print(f"Error: {src_chain} not one of the chains in {bridge}.")

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -7,7 +7,7 @@ from xrpl.models import GenericRequest, Response, SignAndSubmit, Transaction
 
 
 def submit_tx(
-    tx: Transaction, client: SyncClient, seed: str, verbose: bool = False
+    tx: Transaction, client: SyncClient, seed: str, verbose: int = 0
 ) -> Response:
     """
     Submit a transaction to rippled, asking rippled to sign it as well.
@@ -21,11 +21,15 @@ def submit_tx(
     Returns:
         The response from rippled.
     """
-    if verbose:
-        print(f"submitting tx to {client.url}:")
-        pprint(tx.to_xrpl())
+    if verbose > 0:
+        print(f"submitting {tx.transaction_type.value} tx to {client.url}...")
+        if verbose > 1:
+            pprint(tx.to_xrpl())
     result = client.request(SignAndSubmit(transaction=tx, secret=seed))
     client.request(GenericRequest(method="ledger_accept"))
-    if verbose:
+    tx_result = result.result.get("error") or result.result.get("engine_result")
+    if verbose > 0:
+        print(f"Result: {tx_result}")
+    if verbose > 1:
         pprint(result.result)
     return result


### PR DESCRIPTION
## High Level Overview of Change

This PR moves some of the print output to a higher level of verbosity, the `-vv` flag. 

### Context of Change

Some of the output (like the rippled response) really cluttered the output, but it's still very desired if you're running into issues, so I moved it to a new flag.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Works locally.
