### PR TITLE
refactor: use `click.echo` instead of `print`

### DIFF
--- a/sidechain_cli/bridge/setup.py
+++ b/sidechain_cli/bridge/setup.py
@@ -1,7 +1,7 @@
 """CLI command for setting up a bridge."""
 
 import json
-from pprint import pprint
+from pprint import pformat
 from typing import List, Tuple, cast
 
 import click
@@ -124,7 +124,7 @@ def create_bridge(
     }
 
     if verbose:
-        pprint(bridge_data)
+        click.echo(pformat(bridge_data))
     add_bridge(bridge_data)
 
 

--- a/sidechain_cli/bridge/setup.py
+++ b/sidechain_cli/bridge/setup.py
@@ -91,17 +91,17 @@ def create_bridge(
     """
     # check name
     if check_bridge_exists(name):
-        print(f"Bridge named {name} already exists.")
+        click.echo(f"Bridge named {name} already exists.")
         return
     # validate chains
     for chain in chains:
         if not check_chain_exists(chain):
-            print(f"Chain {chain} is not running.")
+            click.echo(f"Chain {chain} is not running.")
             return
     # validate witnesses
     for witness in witnesses:
         if not check_witness_exists(witness):
-            print(f"Witness {witness} is not running.")
+            click.echo(f"Witness {witness} is not running.")
             return
 
     config = get_config().get_witness((witnesses[0])).get_config()

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -133,7 +133,12 @@ def send_transfer(
 
     # XChainSeqNumCreate
     if tutorial:
-        input("\nCreating a cross-chain claim ID on the destination chain...")
+        click.pause(
+            info=click.style(
+                "\nCreating a cross-chain claim ID on the destination chain...",
+                fg="blue",
+            )
+        )
 
     seq_num_tx = XChainCreateClaimID(
         account=to_wallet.classic_address,
@@ -156,7 +161,9 @@ def send_transfer(
 
     # XChainTransfer
     if tutorial:
-        input("\nLocking the funds on the source chain...")
+        click.pause(
+            info=click.style("\nLocking the funds on the source chain...", fg="blue")
+        )
 
     commit_tx = XChainCommit(
         account=from_wallet.classic_address,
@@ -170,14 +177,23 @@ def send_transfer(
     # TODO: wait for the witnesses to send their attestations (once witnesses send
     # their own)
     if tutorial:
-        input("\nRetrieving the proofs from the witness servers...")
+        click.pause(
+            info=click.style(
+                "\nRetrieving the proofs from the witness servers...", fg="blue"
+            )
+        )
     proofs = []
 
     for witness in bridge_config.witnesses:
         witness_config = get_config().get_witness(witness)
 
         if tutorial:
-            input(f"\nRetrieving the proofs from witness {witness_config.name}...")
+            click.pause(
+                info=click.style(
+                    f"\nRetrieving the proofs from witness {witness_config.name}...",
+                    fg="blue",
+                )
+            )
 
         witness_url = f"http://{witness_config.ip}:{witness_config.rpc_port}"
         proof_request = {
@@ -220,7 +236,9 @@ def send_transfer(
         ),
     )
     if tutorial:
-        input("\nSubmitting attestation tx for witnesses...")
+        click.pause(
+            info=click.style("\nSubmitting attestation tx for witnesses...", fg="blue")
+        )
 
     try:
         _submit_tx(

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -108,18 +108,18 @@ def send_transfer(
     print_level = max(verbose, 2 if tutorial else 0)
     bridge_config = get_config().get_bridge(bridge)
     if src_chain not in bridge_config.chains:
-        print(f"Error: {src_chain} not one of the chains in {bridge}.")
+        click.echo(f"Error: {src_chain} not one of the chains in {bridge}.")
         return
 
     try:
         from_wallet = Wallet(from_account, 0)
     except ValueError:
-        print(f"Invalid `from` seed: {from_account}")
+        click.echo(f"Invalid `from` seed: {from_account}")
         return
     try:
         to_wallet = Wallet(to_account, 0)
     except ValueError:
-        print(f"Invalid `to` seed: {to_account}")
+        click.echo(f"Invalid `to` seed: {to_account}")
         return
 
     dst_chain = [chain for chain in bridge_config.chains if chain != src_chain][0]
@@ -200,7 +200,7 @@ def send_transfer(
         if print_level > 1:
             pprint(proof_result)
         elif print_level > 0:
-            print(f"Proof from {witness_config.name} successfully received.")
+            click.echo(f"Proof from {witness_config.name} successfully received.")
 
         if "error" in proof_result:
             error_message = proof_result["error"]["error"]
@@ -233,7 +233,7 @@ def send_transfer(
         if "No such xchain claim id" not in e.args[0]:
             raise e
         if print_level > 0:
-            print(
+            click.echo(
                 "  This means that quorum has already been reached and the funds "
                 "have already been transferred."
             )

--- a/sidechain_cli/bridge/transfer.py
+++ b/sidechain_cli/bridge/transfer.py
@@ -1,6 +1,6 @@
 """CLI command for setting up a bridge."""
 
-from pprint import pprint
+from pprint import pformat
 
 import click
 import httpx
@@ -214,7 +214,7 @@ def send_transfer(
 
         proof_result = httpx.post(witness_url, json=proof_request).json()
         if print_level > 1:
-            pprint(proof_result)
+            click.echo(pformat(proof_result))
         elif print_level > 0:
             click.echo(f"Proof from {witness_config.name} successfully received.")
 

--- a/sidechain_cli/misc/fund.py
+++ b/sidechain_cli/misc/fund.py
@@ -1,6 +1,6 @@
 """Fund an account from the genesis account."""
 
-from pprint import pprint
+from pprint import pformat
 
 import click
 from xrpl.models import AccountInfo, Payment
@@ -48,4 +48,4 @@ def fund_account(chain: str, account: str, verbose: bool = False) -> None:
     )
     submit_tx(payment, client, wallet.seed)
     if verbose:
-        pprint(client.request(AccountInfo(account=account)).result)
+        click.echo(pformat(client.request(AccountInfo(account=account)).result))

--- a/sidechain_cli/server/config/config.py
+++ b/sidechain_cli/server/config/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat
 from sys import platform
 from typing import Any, Dict, Tuple
 
@@ -256,7 +256,7 @@ def generate_bootstrap(
         "witness_reward_seed": witness_reward_seed,
     }
     if verbose:
-        pprint(template_data)
+        click.echo(pformat(template_data))
 
     _generate_template(
         "bootstrap.jinja",

--- a/sidechain_cli/server/list.py
+++ b/sidechain_cli/server/list.py
@@ -15,9 +15,13 @@ def _list_chains() -> None:
     if len(config.chains) == 0:
         click.echo("No chains running.")
         return
+    chains = list(map(asdict, config.chains))
+    for chain in chains:
+        del chain["type"]
+    click.echo("Chains:")
     click.echo(
         tabulate(
-            map(asdict, config.chains),
+            chains,
             headers="keys",
             tablefmt="presto",
         )
@@ -30,9 +34,15 @@ def _list_witnesses() -> None:
     if len(config.witnesses) == 0:
         click.echo("No witnesses running.")
         return
+
+    witnesses = list(map(asdict, config.witnesses))
+    for witness in witnesses:
+        del witness["type"]
+
+    click.echo("Witnesses:")
     click.echo(
         tabulate(
-            map(asdict, config.witnesses),
+            witnesses,
             headers="keys",
             tablefmt="presto",
         )
@@ -43,4 +53,5 @@ def _list_witnesses() -> None:
 def list_servers() -> None:
     """Get a list of running rippled nodes."""
     _list_chains()
+    click.echo("\n")
     _list_witnesses()

--- a/sidechain_cli/server/list.py
+++ b/sidechain_cli/server/list.py
@@ -13,9 +13,9 @@ from sidechain_cli.utils import get_config
 def _list_chains() -> None:
     config = get_config()
     if len(config.chains) == 0:
-        print("No chains running.")
+        click.echo("No chains running.")
         return
-    print(
+    click.echo(
         tabulate(
             map(asdict, config.chains),
             headers="keys",
@@ -28,9 +28,9 @@ def _list_witnesses() -> None:
     """Get a list of running witness nodes."""
     config = get_config()
     if len(config.witnesses) == 0:
-        print("No witnesses running.")
+        click.echo("No witnesses running.")
         return
-    print(
+    click.echo(
         tabulate(
             map(asdict, config.witnesses),
             headers="keys",

--- a/sidechain_cli/server/request.py
+++ b/sidechain_cli/server/request.py
@@ -31,7 +31,8 @@ def request_server(
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
     if verbose:
-        print(f"{name}:", command, *args)
+        arg_string = " ".join(args)
+        click.echo(f"{name}: {command} {arg_string}")
     config = get_config()
     server = config.get_server(name)
 
@@ -39,7 +40,7 @@ def request_server(
         to_run = [server.rippled, "--conf", server.config, command, *args]
         subprocess.call(to_run)
     else:  # is a witness node
-        print("Cannot query witness nodes from the command line right now.")
+        click.echo("Cannot query witness nodes from the command line right now.")
 
 
 @click.command(name="status")
@@ -55,6 +56,6 @@ def get_server_status(name: Optional[str] = None, query_all: bool = False) -> No
         query_all: Whether to stop all of the servers.
     """  # noqa: D301
     if name is None and query_all is False:
-        print("Error: Must specify a name or `--all`.")
+        click.echo("Error: Must specify a name or `--all`.")
         return
-    print(name, query_all)
+    click.echo(f"{name} {query_all}")

--- a/sidechain_cli/server/start.py
+++ b/sidechain_cli/server/start.py
@@ -69,12 +69,12 @@ def start_server(name: str, exe: str, config: str, verbose: bool = False) -> Non
             config_json = json.load(f)
         is_rippled = False
     if check_server_exists(name, config):
-        print("Error: Server already running with that name or config.")
+        click.echo("Error: Server already running with that name or config.")
         return
 
     server_type = "rippled" if is_rippled else "witness"
     if verbose:
-        print(f"Starting {server_type} server {name}...")
+        click.echo(f"Starting {server_type} server {name}...")
 
     if is_rippled:
         to_run = [exe, "--conf", config, "-a"]
@@ -97,9 +97,9 @@ def start_server(name: str, exe: str, config: str, verbose: bool = False) -> Non
     # check if server actually started up correctly
     time.sleep(0.3)
     if process.poll() is not None:
-        print("ERROR")
+        click.echo("ERROR")
         with open(output_file) as f:
-            print(f.read())
+            click.echo(f.read())
         return
 
     if is_rippled:
@@ -130,8 +130,8 @@ def start_server(name: str, exe: str, config: str, verbose: bool = False) -> Non
         add_witness(witness_data)
 
     if verbose:
-        print(f"started {server_type} at `{exe}` with config `{config}`", flush=True)
-        print(f"PID: {pid}", flush=True)
+        click.echo(f"started {server_type} at `{exe}` with config `{config}`")
+        click.echo(f"PID: {pid}")
 
 
 @click.command(name="start-all")
@@ -184,7 +184,7 @@ def start_all_servers(
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
     if not os.path.isdir(config_dir):
-        print(f"Error: {config_dir} is not a directory.")
+        click.echo(f"Error: {config_dir} is not a directory.")
         return
     chains = []
     witnesses = []
@@ -233,7 +233,7 @@ def stop_server(
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
     if name is None and stop_all is False:
-        print("Error: Must specify a name or `--all`.")
+        click.echo("Error: Must specify a name or `--all`.")
         return
     config = get_config()
     if stop_all:
@@ -245,7 +245,7 @@ def stop_server(
         servers = [config.get_server(name)]
     if verbose:
         server_names = ",".join([server.name for server in servers])
-        print(f"Shutting down: {server_names}")
+        click.echo(f"Shutting down: {server_names}")
 
     # fout = open(os.devnull, "w")
     for server in servers:
@@ -262,7 +262,7 @@ def stop_server(
             pid = server.pid
             os.kill(pid, signal.SIGINT)
         if verbose:
-            print(f"Stopped {server.name}")
+            click.echo(f"Stopped {server.name}")
 
     remove_server(name, stop_all)
 
@@ -293,7 +293,7 @@ def restart_server(
         verbose: Whether or not to print more verbose information.
     """  # noqa: D301
     if name is None and restart_all is False:
-        print("Error: Must specify a name or `--all`.")
+        click.echo("Error: Must specify a name or `--all`.")
         return
 
     config = get_config()

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -2,6 +2,7 @@
 
 from pprint import pprint
 
+import click
 from xrpl.clients.sync_client import SyncClient
 from xrpl.models import GenericRequest, Response, SignAndSubmit, Transaction
 
@@ -22,14 +23,14 @@ def submit_tx(
         The response from rippled.
     """
     if verbose > 0:
-        print(f"submitting {tx.transaction_type.value} tx to {client.url}...")
+        click.echo(f"submitting {tx.transaction_type.value} tx to {client.url}...")
         if verbose > 1:
             pprint(tx.to_xrpl())
     result = client.request(SignAndSubmit(transaction=tx, secret=seed))
     client.request(GenericRequest(method="ledger_accept"))
     tx_result = result.result.get("error") or result.result.get("engine_result")
     if verbose > 0:
-        print(f"Result: {tx_result}")
+        click.echo(f"Result: {tx_result}")
     if verbose > 1:
         pprint(result.result)
     return result

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -23,14 +23,17 @@ def submit_tx(
         The response from rippled.
     """
     if verbose > 0:
-        click.echo(f"submitting {tx.transaction_type.value} tx to {client.url}...")
+        click.secho(
+            f"submitting {tx.transaction_type.value} tx to {client.url}...", fg="blue"
+        )
         if verbose > 1:
             pprint(tx.to_xrpl())
     result = client.request(SignAndSubmit(transaction=tx, secret=seed))
     client.request(GenericRequest(method="ledger_accept"))
     tx_result = result.result.get("error") or result.result.get("engine_result")
     if verbose > 0:
-        click.echo(f"Result: {tx_result}")
+        text_color = "bright_green" if tx_result == "tesSUCCESS" else "bright_red"
+        click.secho(f"Result: {tx_result}", fg=text_color)
     if verbose > 1:
         pprint(result.result)
     return result

--- a/sidechain_cli/utils/transaction.py
+++ b/sidechain_cli/utils/transaction.py
@@ -1,6 +1,6 @@
 """Utils related to transactions."""
 
-from pprint import pprint
+from pprint import pformat
 
 import click
 from xrpl.clients.sync_client import SyncClient
@@ -27,7 +27,7 @@ def submit_tx(
             f"submitting {tx.transaction_type.value} tx to {client.url}...", fg="blue"
         )
         if verbose > 1:
-            pprint(tx.to_xrpl())
+            click.echo(pformat(tx.to_xrpl()))
     result = client.request(SignAndSubmit(transaction=tx, secret=seed))
     client.request(GenericRequest(method="ledger_accept"))
     tx_result = result.result.get("error") or result.result.get("engine_result")
@@ -35,5 +35,5 @@ def submit_tx(
         text_color = "bright_green" if tx_result == "tesSUCCESS" else "bright_red"
         click.secho(f"Result: {tx_result}", fg=text_color)
     if verbose > 1:
-        pprint(result.result)
+        click.echo(pformat(result.result))
     return result


### PR DESCRIPTION
## High Level Overview of Change

This PR replaces all instances of `print` with `click.echo` and `pprint` with `click.echo(pformat())`. It also adds some colors to some of the outputs to make them easier to read.

### Context of Change

The Click-native method of printing is to use the method `click.echo` instead of the standard Python `print`. 

### Type of Change

- [x] Refactor (non-breaking change that only restructures code)

## Test Plan

Works locally.
